### PR TITLE
Add user support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 1. `git clone https://github.com/benbalter/count-org-loc && cd count-org-loc`
 2. `gem install bundler`
 3. `script/bootstrap`
-4. `script/count [ORG_NAME]`
+4. `script/count [ORG_NAME | USER_NAME]`
 
 ## How it works
 
-It uses [Octokit.rb](https://github.com/octokit/octokit.rb) to fetch a list of your organization's repositories (public or public and private), and [Cloc](https://github.com/AlDanial/cloc) to count the lines of code, number of files, comments, etc.
+It uses [Octokit.rb](https://github.com/octokit/octokit.rb) to fetch a list of your organization's (or user's) repositories (public or public and private), and [Cloc](https://github.com/AlDanial/cloc) to count the lines of code, number of files, comments, etc.
 
 ## Example output for @whitehouse
 

--- a/loc.rb
+++ b/loc.rb
@@ -32,7 +32,11 @@ end
 client = Octokit::Client.new access_token: ENV['GITHUB_TOKEN']
 client.auto_paginate = true
 
-repos = client.organization_repositories(ARGV[0].strip, type: 'sources')
+begin
+  repos = client.organization_repositories(ARGV[0].strip, type: 'sources')
+rescue
+  repos = client.repositories(ARGV[0].strip, type: 'sources')
+end
 puts "Found #{repos.count} repos. Counting..."
 
 reports = []


### PR DESCRIPTION
I have made it so that if you put in a GitHub user's username it will pull all of the GH repos they have created or forked and will run the same math as before. (Note currently this counts all commits regardless of author however if I get to it I will add support for only counting lines authored by the user. However, I figured that should be a separate feature and command)