### PR TITLE
Add option to run github action on linux runner and fix token issue

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,59 @@
+name: Get Lines of Code for GitHub Organizations
+on:
+  workflow_dispatch:
+    inputs:
+      test_org_name:
+        description: 'Name of the TEST environment GitHub Organization(s)'
+        required: true
+        default: ''
+      prod_org_name:
+        description: 'Name of the PROD environment GitHub Organization(s)'
+        required: true
+        default: ''
+env:
+  GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.0
+
+      - name: Install Dependencies and Cleanup
+        run: sudo apt-get install -y cloc
+
+      - name: Calculating LoC for each org
+        run: |
+          IFS=',' read -ra ORGS <<< "${{ github.event.inputs.test_org_name }}"
+          for org in "${ORGS[@]}"; do
+            bundle exec ruby loc.rb "$org"
+          done
+  prod:
+    timeout-minutes: 60
+    needs: test
+    #May need to add a "Pay as you go", larger GitHub-hosted runner depending on the size of each repo
+    #See https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.0
+
+      - name: Install Dependencies and Cleanup
+        run: sudo apt-get install -y cloc
+
+      - name: Calculating LoC for each org
+        run: |
+          IFS=',' read -ra ORGS <<< "${{ github.event.inputs.prod_org_name }}"
+          for org in "${ORGS[@]}"; do
+            bundle exec ruby loc.rb "$org"
+          done

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -7,6 +7,8 @@ on:
         description: 'The org (or user) to calculate total lines of code'
         required: false
         type: string
+env:
+  GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
 jobs:
   run:
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Don't want to set up a local development environment? You can run this script vi
 
 You'll see the progress and count(s) in the job output (also available from the Actions tab).
 
-Note: If you'd like to count private repositories, as described below, you'll need to set a `GITHUB_TOKEN` GitHub Actions secret.
+Note: If you'd like to count private repositories, as described below, you'll need to set an `ORG_GITHUB_TOKEN` GitHub Actions secret with your PAT.
 
 ## How it works
 


### PR DESCRIPTION
- Grants ability to input csv of orgs and iterate through each one
- Adds linux option for a runner
- Adds option for test job (linux)
- Fixes token issue https://github.com/benbalter/count-org-loc/issues/11