### PR TITLE
Skip archived repositories when counting org LOC

### DIFF
--- a/loc.rb
+++ b/loc.rb
@@ -37,6 +37,7 @@ begin
 rescue StandardError
   repos = client.repositories(ARGV[0].strip, type: 'sources')
 end
+repos = repos.reject(&:archived)
 puts "Found #{repos.count} repos. Counting..."
 
 reports = []


### PR DESCRIPTION
## Summary
- Filter out archived repositories after fetching org/user repo lists via Octokit
- Ensures archived (read-only, often stale) repos are not cloned or included in LOC totals

## Test plan
- [ ] Run `script/count <org-with-archived-repos>` and confirm archived repos are excluded from the "Found N repos" count
- [ ] Verify active repos are still cloned and counted as before
- [ ] Confirm user-account fallback (`client.repositories`) also skips archived repos


Made with [Cursor](https://cursor.com)